### PR TITLE
not used anymore and breaks nested service groups

### DIFF
--- a/ciscoasa/objects_networkservicegroups.go
+++ b/ciscoasa/objects_networkservicegroups.go
@@ -118,10 +118,6 @@ func (s *objectsService) CreateNetworkServiceGroup(name, description string, mem
 	}
 
 	for _, member := range members {
-		if !strings.Contains(member, "/") {
-			member = fmt.Sprintf("/%s", member)
-		}
-
 		o, err := s.objectFromService(member)
 		if err != nil {
 			return nil, err
@@ -169,10 +165,6 @@ func (s *objectsService) UpdateNetworkServiceGroup(name, description string, mem
 	}
 
 	for _, member := range members {
-		if !strings.Contains(member, "/") {
-			member = fmt.Sprintf("/%s", member)
-		}
-
 		o, err := s.objectFromService(member)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I think this was a leftover from back when I wrote port/protocol instead of protocol/port services. Doesn't seem to service a purpose now and it broke the integration test on the terraform provider for nested groups, which is now working again:
TestAccCiscoASANetworkServiceGroup
=== RUN   TestAccCiscoASANetworkServiceGroup
--- PASS: TestAccCiscoASANetworkServiceGroup (4.23s)
PASS
ok  	github.com/xanzy/terraform-provider-ciscoasa/ciscoasa	4.240s 