### PR TITLE
Enable go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/xanzy/go-ciscoasa


### PR DESCRIPTION
This PR is a result of the following commands:

```
go mod init
go get ./...
go mod tidy
```

This will make it easier and safer to use this library downstream as go modules tooling will know better how to pin versions and resolve version conflicts.