### PR TITLE
Set "User-Agent" header

### DIFF
--- a/ciscoasa/ciscoasa.go
+++ b/ciscoasa/ciscoasa.go
@@ -145,6 +145,7 @@ func (c *Client) newRequest(method string, api string, v interface{}) (*http.Req
 
 	req.Close = true
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Set("User-Agent", "REST API Agent")
 	req.SetBasicAuth(c.username, c.password)
 
 	return req, nil


### PR DESCRIPTION
Newer versions of the Cisco API require the User-Agent header to be one of `REST API Agent`, `ASDM` or `CSM`.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>